### PR TITLE
One less dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "author": "Pomax",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.13.4",
-    "node-jsx": "^0.13.3"
+    "express": "^4.13.4"
   },
   "devDependencies": {
     "babel-core": "^6.5.2",

--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
 // shim nodejs so it can load .jsx files
-require('node-jsx').install({harmony: true});
+require(`babel-core/register`);
 var reactRouted = require('./middleware.jsx');
 
 // and a simple server


### PR DESCRIPTION
Since you're already have babel-core in there we can just use the /register for that :)
